### PR TITLE
Remove 4-byte write from TFramedTransport constructor

### DIFF
--- a/lib/java/src/org/apache/thrift/transport/TFramedTransport.java
+++ b/lib/java/src/org/apache/thrift/transport/TFramedTransport.java
@@ -78,13 +78,11 @@ public class TFramedTransport extends TTransport {
   public TFramedTransport(TTransport transport, int maxLength) {
     transport_ = transport;
     maxLength_ = maxLength;
-    writeBuffer_.write(sizeFiller_, 0, 4);
   }
 
   public TFramedTransport(TTransport transport) {
     transport_ = transport;
     maxLength_ = TFramedTransport.DEFAULT_MAX_LENGTH;
-    writeBuffer_.write(sizeFiller_, 0, 4);
   }
 
   @Override

--- a/lib/java/src/org/apache/thrift/transport/THeaderTransport.java
+++ b/lib/java/src/org/apache/thrift/transport/THeaderTransport.java
@@ -667,8 +667,7 @@ public class THeaderTransport extends TFramedTransport {
             // Allocate buffer for the headers.
             // 14 bytes for sz, magic , flags , seqId , headerSize
             ByteBuffer out = ByteBuffer.allocate(headerSize + 14);
-            // Account for additional padding of 4 bytes, compared to Circus
-            frame.position(4);
+
             // See thrift/doc/HeaderFormat.txt for more info on wire format
             encodeInt(out, 10 + headerSize + frame.remaining());
             encodeShort(out, HEADER_MAGIC >> 16);


### PR DESCRIPTION
- There is an issue with 4-byte offset that occurs with the current implementation of TFramedTransport
- The constructors for the transport are adding an additional 4 bytes before anything is written
- Python implementation of TFramedTransport does not include this additional writing
- These are extra and neither THeader, TBinary or TCompact does not count these bytes
- Previous fix `frame.position(4)` during `flush` was an incomplete solution as it jumped ahead by 4 bytes to account for this additional writing and find the expected bytes, but then that introduced a new permanent offset for subsequent thrift requests. The first request passed, but requests after that failed. This PR reverts that