### PR TITLE
Make header length size 4 bytes to be compatible with circus

### DIFF
--- a/lib/java/src/org/apache/thrift/transport/THeaderTransport.java
+++ b/lib/java/src/org/apache/thrift/transport/THeaderTransport.java
@@ -376,6 +376,7 @@ public class THeaderTransport extends TTransport {
                 /* Read length of the header.
                  * We are using 4 bytes to store the header length instead of 2, to deal with
                  * headers larger than 65535 bytes
+                 * Related: https://github.com/carta/circus/pull/123
                  */
                 int headerSize = decodeWord(buff, 8);
 
@@ -734,7 +735,7 @@ public class THeaderTransport extends TTransport {
               2 bytes for header magic
             + 2 bytes for flags
             + 4 bytes for sequence id
-            + 4 bytes for header length (instead of 2 bytes)
+            + 4 bytes for header length (instead of 2 bytes. Related: https://github.com/carta/circus/pull/123)
             = 12
              */
             encodeInt(out, 12 + headerSize + frame.remaining());
@@ -743,6 +744,7 @@ public class THeaderTransport extends TTransport {
             encodeInt(out, seqId);
             /* We are using 4 bytes to store the header length instead of 2, to deal with
              * headers larger than 65535 bytes
+             * Related: https://github.com/carta/circus/pull/123
              */
             encodeInt(out, headerSize / 4);
 

--- a/lib/java/src/org/apache/thrift/transport/THeaderTransport.java
+++ b/lib/java/src/org/apache/thrift/transport/THeaderTransport.java
@@ -373,6 +373,10 @@ public class THeaderTransport extends TTransport {
                 flags = version & HEADER_FLAGS_MASK;
                 // read seqId
                 seqId = decodeWord(buff, 4);
+                /* Read length of the header.
+                 * We are using 4 bytes to store the header length instead of 2, to deal with
+                 * headers larger than 65535 bytes
+                 */
                 int headerSize = decodeWord(buff, 8);
 
                 readHeaderFormat(headerSize, buff);
@@ -443,7 +447,7 @@ public class THeaderTransport extends TTransport {
 
     private void readHeaderFormat(int headerSize, byte[] buff) throws TTransportException {
         ByteBuffer frame = ByteBuffer.wrap(buff);
-        frame.position(12); // Advance past version, flags, seqid
+        frame.position(12); // Advance past version, flags, seqid, length of headers
 
         headerSize = headerSize * 4;
         int endHeader = headerSize + frame.position();
@@ -722,14 +726,24 @@ public class THeaderTransport extends TTransport {
             headerSize += paddingSize;
 
             // Allocate buffer for the headers.
-            // 14 bytes for sz, magic , flags , seqId , headerSize
+            // 16 bytes for sz, magic , flags , seqId , length of header
             ByteBuffer out = ByteBuffer.allocate(headerSize + 16);
 
             // See thrift/doc/HeaderFormat.txt for more info on wire format
+            /*
+              2 bytes for header magic
+            + 2 bytes for flags
+            + 4 bytes for sequence id
+            + 4 bytes for header length (instead of 2 bytes)
+            = 12
+             */
             encodeInt(out, 12 + headerSize + frame.remaining());
             encodeShort(out, HEADER_MAGIC >> 16);
             encodeShort(out, flags);
             encodeInt(out, seqId);
+            /* We are using 4 bytes to store the header length instead of 2, to deal with
+             * headers larger than 65535 bytes
+             */
             encodeInt(out, headerSize / 4);
 
             out.put(headerData);

--- a/lib/java/src/org/apache/thrift/transport/THeaderTransport.java
+++ b/lib/java/src/org/apache/thrift/transport/THeaderTransport.java
@@ -373,7 +373,7 @@ public class THeaderTransport extends TTransport {
                 flags = version & HEADER_FLAGS_MASK;
                 // read seqId
                 seqId = decodeWord(buff, 4);
-                int headerSize = decodeShort(buff, 8);
+                int headerSize = decodeWord(buff, 8);
 
                 readHeaderFormat(headerSize, buff);
             } else {
@@ -443,7 +443,7 @@ public class THeaderTransport extends TTransport {
 
     private void readHeaderFormat(int headerSize, byte[] buff) throws TTransportException {
         ByteBuffer frame = ByteBuffer.wrap(buff);
-        frame.position(10); // Advance past version, flags, seqid
+        frame.position(12); // Advance past version, flags, seqid
 
         headerSize = headerSize * 4;
         int endHeader = headerSize + frame.position();
@@ -707,7 +707,7 @@ public class THeaderTransport extends TTransport {
             ByteBuffer infoData1 = flushInfoHeaders(Infos.INFO_PKEYVALUE, writePersistentHeaders);
             ByteBuffer infoData2 = flushInfoHeaders(Infos.INFO_KEYVALUE, writeHeaders);
 
-            ByteBuffer headerData = ByteBuffer.allocate(10);
+            ByteBuffer headerData = ByteBuffer.allocate(12);
             writeVarint(headerData, protoId);
             writeVarint(headerData, numTransforms);
             headerData.limit(headerData.position());
@@ -723,14 +723,14 @@ public class THeaderTransport extends TTransport {
 
             // Allocate buffer for the headers.
             // 14 bytes for sz, magic , flags , seqId , headerSize
-            ByteBuffer out = ByteBuffer.allocate(headerSize + 14);
+            ByteBuffer out = ByteBuffer.allocate(headerSize + 16);
 
             // See thrift/doc/HeaderFormat.txt for more info on wire format
-            encodeInt(out, 10 + headerSize + frame.remaining());
+            encodeInt(out, 12 + headerSize + frame.remaining());
             encodeShort(out, HEADER_MAGIC >> 16);
             encodeShort(out, flags);
             encodeInt(out, seqId);
-            encodeShort(out, headerSize / 4);
+            encodeInt(out, headerSize / 4);
 
             out.put(headerData);
             out.put(transformData);

--- a/lib/java/src/org/apache/thrift/transport/THeaderTransport.java
+++ b/lib/java/src/org/apache/thrift/transport/THeaderTransport.java
@@ -707,7 +707,7 @@ public class THeaderTransport extends TTransport {
             ByteBuffer infoData1 = flushInfoHeaders(Infos.INFO_PKEYVALUE, writePersistentHeaders);
             ByteBuffer infoData2 = flushInfoHeaders(Infos.INFO_KEYVALUE, writeHeaders);
 
-            ByteBuffer headerData = ByteBuffer.allocate(12);
+            ByteBuffer headerData = ByteBuffer.allocate(10);
             writeVarint(headerData, protoId);
             writeVarint(headerData, numTransforms);
             headerData.limit(headerData.position());


### PR DESCRIPTION
Increasing the header size in order to be compatible with upcoming changes in the THeaderTransport used by Circus - https://github.com/carta/circus/pull/123